### PR TITLE
Enforce numpy-style docstrings via ruff pydocstyle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,14 @@ select = [
     "C4",     # flake8-comprehensions
     "SIM",    # flake8-simplify
     "ANN",    # flake8-annotations
+    "D",      # pydocstyle (numpy convention)
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- Enable Ruff's pydocstyle (`D`) rules with the `numpy` convention to lint docstring style on `src/`
- Exempt `tests/**` from docstring requirements via per-file-ignores

## Details
The codebase already uses numpy-style docstrings (e.g. `johnson_relative_weights` with `Parameters`/`Returns`/`Raises`/`Notes`/`References`/`Examples`), but Ruff wasn't enforcing it. This adds `"D"` to the lint `select` list and sets `convention = "numpy"`, which auto-ignores the rules that conflict with the numpy convention.

## Testing
- `ruff check src tests` → All checks passed!

🤖 Generated with [Claude Code](https://claude.com/claude-code)